### PR TITLE
Added command line options and arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,19 @@ Usage
 
 Start a server with default settings in the current directory:
 
-    $ cd /path/to/myapp/docroot
-    $ simphle
+```console
+$ cd /path/to/myapp/docroot
+$ simphle
+```
 
+### Intermediate
+
+Start a server with custom settings from the command line:
+
+```console
+$ cd /path/to/myapp
+$ simphle [-H host] [-p port] [-c path/to/php.ini] [-r path/to/router.php] [path/to/docroot]
+```
 
 ### Advanced
 
@@ -75,7 +85,7 @@ Create a `scripts` section in you `composer.json`:
 
 ```json
 "scripts": {
-    "server": "simphle"
+    "server": "simphle [options]"
 }
 ```
 

--- a/bin/simphle
+++ b/bin/simphle
@@ -10,6 +10,7 @@ if (file_exists(dirname(__FILE__) . '/../vendor/autoload.php')) {
 
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
+use CLIParser\CliParser;
 
 // Set some defaults
 $config = array(
@@ -51,6 +52,41 @@ if (is_readable($config['cwd'] . '/server.json')) {
             $config[$key] = $data[$key];
         }
     }
+}
+
+// Look for command line arguments to override server.json file
+// Define some options
+$shortOptions = 'H:p:c:r:';
+$longOptions = array(
+    array('controller', true)
+);
+$cli = new CLIParser($shortOptions, $longOptions);
+$program = $cli->program();
+$options = $cli->options();
+$args = $cli->arguments();
+
+if (!empty($options['H'])) {
+    $config['host'] = $options['H'];
+}
+
+if (!empty($options['p'])) {
+    $config['port'] = $options['p'];
+}
+
+if (!empty($options['c'])) {
+    $config['ini'] = $options['c'];
+}
+
+if (!empty($options['r'])) {
+    $config['router'] = $options['r'];
+}
+
+if (!empty($options['controller'])) {
+    $config['controller'] = $options['controller'];
+}
+
+if (!empty($args[0])) {
+    $config['docroot'] = $args[0];
 }
 
 // Compose the header

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=5.4",
         "symfony/process": "~2.6",
-        "monolog/monolog": "~1.13"
+        "monolog/monolog": "~1.13",
+        "vtardia/cli-parser": "^1.0"
     },
     "autoload": {
         "psr-0": { "Simphle": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require": {
         "php": ">=5.4",
         "symfony/process": "~2.6",
-        "monolog/monolog": "~1.13",
         "vtardia/cli-parser": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
Common server options can now be passed as command line switch, while the first argument is the document root.

Note: console options and arguments override the same settings in `server.json`.
