### PR TITLE
fix CLIParser class name

### DIFF
--- a/bin/simphle
+++ b/bin/simphle
@@ -10,7 +10,7 @@ if (file_exists(dirname(__FILE__) . '/../vendor/autoload.php')) {
 
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
-use CLIParser\CliParser;
+use CLIParser\CLIParser;
 
 // Set some defaults
 $config = array(


### PR DESCRIPTION
Hola Amigo, 

Aquí te propongo una corrección para poder usar simphle server con PHP 7.2 en servidores linux

Saludos, Hernán.